### PR TITLE
add sign in screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:ecoland_application/providers/user_settings_provider.dart';
+import 'package:ecoland_application/screens/sign_in_screen.dart';
 import 'package:ecoland_application/screens/signup_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -39,10 +40,11 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: SignupScreen(),
+      home: SignInScreen(),
       routes: {
         "/sign-up": (context) => SignupScreen(),
-        "/sign-in": (context) => MyHomePage(title: "title")
+        "/sign-in": (context) => SignInScreen(),
+        "/overview": (context) => MyHomePage(title: "title")
       },
     );
   }

--- a/lib/providers/api/authentication.dart
+++ b/lib/providers/api/authentication.dart
@@ -1,22 +1,24 @@
+import 'dart:convert';
+
 import 'package:http/http.dart';
 import './config.dart';
 
 Future<bool> signUp(String username, String email, String password) async {
-  const baseUrl = AppConfig.baseUrl;
-  const url = '$baseUrl/authentication/sign-up';
+  final url = '${AppConfig.baseUrl}/authentication/sign-up';
   try {
-    Response response = await post(Uri.parse(url), body: {
+    final Map<String, dynamic> object = {
       'username': username,
       'email': email,
       'password': password,
-    });
-
+    };
+    Response response = await post(Uri.parse(url), body: jsonEncode(object));
     if (response.statusCode == 201) {
       return true;
     } else {
       return false;
     }
   } catch (e) {
+    print(e);
     return false;
   }
 }

--- a/lib/providers/api/config.dart
+++ b/lib/providers/api/config.dart
@@ -1,5 +1,17 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
 class AppConfig {
-  static const String baseUrl = 'http://localhost:8081';
+  static String get baseUrl {
+    if (kIsWeb) {
+      return 'http://localhost:8081'; // Web
+    } else if (Platform.isAndroid) {
+      return 'http://10.0.2.2:8081'; // Android Emulator
+    } else {
+      return 'http://localhost:8081'; // Default (e.g., iOS, desktop)
+    }
+  }
   static const Map<String, String> defaultHeaders = {
     'Content-Type': 'application/json',
   };

--- a/lib/providers/user_settings_provider.dart
+++ b/lib/providers/user_settings_provider.dart
@@ -5,8 +5,6 @@ import 'package:ecoland_application/providers/api/config.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 
-const baseUrl = AppConfig.baseUrl;
-
 class UserSettingsProvider with ChangeNotifier {
   String _accessToken = '';
   String _refreshToken = '';
@@ -27,26 +25,34 @@ class UserSettingsProvider with ChangeNotifier {
     );
   }
 
-  Future<bool> signIn(String url, String username, String password) async {
-    final response = await http.post(
-      Uri.parse('$baseUrl/authentication/sign-in'),
-      body: {'username': username, 'password': password},
-    );
+  Future<bool> signIn(String username, String password) async {
+    bool success = false;
+    final object = {'username': username, 'password': password};
+    print(AppConfig.baseUrl);
+    try {
 
-    if (response.statusCode == 200) {
-      final responseBody = jsonDecode(response.body);
-      final at = responseBody['accessToken'];
-      final rt = responseBody['refreshToken'];
-      setAccessToken(at, rt);
-      return true;
-    } else {
-      throw Exception('Failed to sign in');
+      final response = await http.post(
+        Uri.parse('${AppConfig.baseUrl}/authentication/sign-in'),
+        body: jsonEncode(object),
+      );
+      if (response.statusCode == 200) {
+        final responseBody = jsonDecode(response.body);
+        final at = responseBody['accessToken'];
+        final rt = responseBody['refreshToken'];
+        setAccessToken(at, rt);
+        success = true;
+      } else {
+        throw Exception('Failed to sign in');
+      }
+    } catch (e) {
+      throw Exception("Call failed");
     }
+    return success;
   }
 
   Future<void> _refreshAccessToken() async {
     final response = await http.post(
-      Uri.parse('$baseUrl/authentication/refresh-token'),
+      Uri.parse('${AppConfig.baseUrl}/authentication/refresh-token'),
       headers: {'Authorization': 'Bearer $_refreshToken'},
     );
 

--- a/lib/screens/sign_in_screen.dart
+++ b/lib/screens/sign_in_screen.dart
@@ -1,0 +1,65 @@
+import 'package:ecoland_application/providers/user_settings_provider.dart';
+import 'package:flutter/material.dart';
+
+class SignInScreen extends StatefulWidget {
+  const SignInScreen({super.key});
+
+  @override
+  State<SignInScreen> createState() => _SignInScreenState();
+}
+
+onPressed(String username, String password) async {}
+
+class _SignInScreenState extends State<SignInScreen> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("SignIn"),
+      ),
+      body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: <Widget>[
+              TextField(
+                controller: _usernameController,
+              ),
+              TextField(
+                controller: _passwordController,
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              ElevatedButton(
+                  onPressed: () async {
+                    final navigator = Navigator.of(context);
+                    if (_usernameController.text == "" ||
+                        _passwordController.text == "") {
+                      //ToDo: Show error username or password can't be empty
+                      return;
+                    }
+                    bool signedIn = await UserSettingsProvider().signIn(
+                        _usernameController.text, _passwordController.text);
+                    if (signedIn) {
+                      navigator.popAndPushNamed("/overview");
+                    } else {
+                      print("could not login");
+                    }
+                  },
+                  child: const Text("Sign In")),
+              const SizedBox(
+                height: 20,
+              ),
+              ElevatedButton(
+                  onPressed: () {
+                    final navigator = Navigator.of(context);
+                    navigator.pushNamed("/sign-up");
+                  },
+                  child: const Text("Sign Up here")),
+            ],
+          )),
+    );
+  }
+}

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -41,17 +41,19 @@ class _SignupScreenState extends State<SignupScreen> {
             TextField(
               controller: _confirmPasswordController,
               decoration: const InputDecoration(labelText: 'Confirm Password'),
+              obscureText: true,
             ),
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () async {
+                final navigator = Navigator.of(context);
                 if (_confirmPasswordController.text ==
                     _passwordController.text) {
                   bool success = await signUp(_usernameController.text,
                       _emailController.text, _passwordController.text);
                   if (success) {
                     if (!mounted) return;
-                    Navigator.pushReplacementNamed(context, '/sign-in');
+                    navigator.pushReplacementNamed('/sign-in');
                   }
                 }
               },


### PR DESCRIPTION
This pull request includes several changes to improve the authentication flow and enhance the user interface. The most important changes include adding a sign-in screen, updating the API configuration to handle different platforms, and modifying the sign-up and sign-in processes.

### Authentication flow improvements:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L42-R47): Changed the home screen to `SignInScreen` and updated the routes to include `/overview` and use `SignInScreen` for the `/sign-in` route.
* [`lib/providers/api/authentication.dart`](diffhunk://#diff-e1317acdbc162aec1a13c4e3617362826d02112341ad7dbf7273ce37bf06b478R1-R21): Refactored the `signUp` function to use JSON encoding for the request body and added error logging.
* [`lib/providers/api/config.dart`](diffhunk://#diff-300d76e4c69835529e3a9afc8af1b693e7968a9cc5e79002c48dfa013070cf60R1-R14): Updated `AppConfig` to return different base URLs based on the platform (web, Android, or default).
* [`lib/providers/user_settings_provider.dart`](diffhunk://#diff-1d0916a8a08228e5c220b4d7615094e6754d135153caef6e046a9de283731985L30-R55): Updated the `signIn` function to use JSON encoding for the request body and added error handling. Removed the hardcoded base URL.

### User interface enhancements:

* [`lib/screens/sign_in_screen.dart`](diffhunk://#diff-19dc687c3c8aaaaf9b77fde78b59507c23d9871f114759978ed3f00a56c09b99R1-R65): Added a new `SignInScreen` with text fields for username and password, and buttons for sign-in and navigation to the sign-up screen.
* [`lib/screens/signup_screen.dart`](diffhunk://#diff-e5c9a5c312a2c33710db7753c0b79296167b6f99a7b941a3a6b9bc1eec37f82eR44-R56): Added `obscureText` property to the confirm password field and used a navigator variable for navigation.