### PR TITLE
add notification

### DIFF
--- a/lib/components/notification.dart
+++ b/lib/components/notification.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+enum NotificationType { success, error, warning }
+
+class CustomNotification extends StatelessWidget {
+  final String message;
+  final NotificationType type;
+  final VoidCallback onClose;
+
+  const CustomNotification({
+    super.key,
+    required this.message,
+    required this.type,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Color backgroundColor;
+    IconData icon;
+
+    switch (type) {
+      case NotificationType.success:
+        backgroundColor = const Color(0xFF4CAF50);
+        icon = Icons.check_circle;
+        break;
+      case NotificationType.error:
+        backgroundColor = const Color(0xFFE57373);
+        icon = Icons.error;
+        break;
+      case NotificationType.warning:
+        backgroundColor = const Color(0xFFFFB74D);
+        icon = Icons.warning;
+        break;
+    }
+
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: Colors.white),
+              const SizedBox(width: 8),
+              Text(
+                message,
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
+            ],
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, color: Colors.white),
+            onPressed: onClose,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void showCustomNotification(
+  BuildContext context, {
+  required String message,
+  required NotificationType type,
+  int durationInSeconds = 0,
+}) {
+  OverlayState? overlayState = Overlay.of(context);
+  late OverlayEntry overlayEntry;
+
+  overlayEntry = OverlayEntry(
+    builder: (context) => Positioned(
+      bottom: 20,
+      left: 20,
+      right: 20,
+      child: CustomNotification(
+        message: message,
+        type: type,
+        onClose: () {
+          overlayEntry.remove();
+        },
+      ),
+    ),
+  );
+
+  overlayState.insert(overlayEntry);
+  if (durationInSeconds != 0) {
+    Future.delayed(Duration(seconds: durationInSeconds), () {
+      overlayEntry.remove();
+    });
+  }
+  ;
+}

--- a/lib/screens/sign_in_screen.dart
+++ b/lib/screens/sign_in_screen.dart
@@ -1,3 +1,4 @@
+import 'package:ecoland_application/components/notification.dart';
 import 'package:ecoland_application/navigation/routes.dart';
 import 'package:ecoland_application/providers/user_settings_provider.dart';
 import 'package:flutter/material.dart';
@@ -45,12 +46,17 @@ class _SignInScreenState extends State<SignInScreen> {
                       //ToDo: Show error username or password can't be empty
                       return;
                     }
-                    bool signedIn = await userSettings.signIn(
-                        _usernameController.text, _passwordController.text);
-                    if (signedIn) {
-                      navigator.popAndPushNamed(Routes.overview);
-                    } else {
+                    try {
+                      bool signedIn = await userSettings.signIn(
+                          _usernameController.text, _passwordController.text);
+                      if (signedIn) {
+                        navigator.popAndPushNamed(Routes.overview);
+                      }
+                    } catch (e) {
                       print("could not login");
+                      showCustomNotification(context,
+                          message: "could not login!",
+                          type: NotificationType.error);
                     }
                   },
                   child: const Text("Sign In")),

--- a/lib/screens/user_settings_screen.dart
+++ b/lib/screens/user_settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:ecoland_application/components/notification.dart';
 import 'package:ecoland_application/providers/user_settings_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -54,12 +55,21 @@ class _UserSettingsScreenState extends State<UserSettingsScreen> {
         newPassword: _newPasswordController.text,
         eMail: _emailController.text,
       );
-
+      print('success: $success');
+      if (!mounted) return;
       if (success) {
+        showCustomNotification(context,
+            message: "Successfully Updated Settings",
+            type: NotificationType.success,
+            durationInSeconds: 10);
         _usernameController.text = provider.userName;
         _emailController.text = provider.eMail;
+      } else {
+        showCustomNotification(context,
+            message: "Error updating Settings",
+            type: NotificationType.error,
+            durationInSeconds: 10);
       }
-      print('success: $success');
     }
   }
 


### PR DESCRIPTION
This pull request introduces a new custom notification system and integrates it into the sign-in and user settings screens. The most important changes include the creation of the `CustomNotification` widget, the addition of the `showCustomNotification` function, and the integration of these into the sign-in and user settings screens to provide user feedback.

### Notification System Implementation:

* [`lib/components/notification.dart`](diffhunk://#diff-bc252e919387f0664b6b2e014e19b42f08ec861cde846b65204fa7d68d1e4907R1-R98): Added a new `CustomNotification` widget and `showCustomNotification` function to display notifications with different types (success, error, warning).

### Integration into Screens:

* [`lib/screens/sign_in_screen.dart`](diffhunk://#diff-19dc687c3c8aaaaf9b77fde78b59507c23d9871f114759978ed3f00a56c09b99R1): Imported the new notification component and modified the sign-in logic to show an error notification when login fails. [[1]](diffhunk://#diff-19dc687c3c8aaaaf9b77fde78b59507c23d9871f114759978ed3f00a56c09b99R1) [[2]](diffhunk://#diff-19dc687c3c8aaaaf9b77fde78b59507c23d9871f114759978ed3f00a56c09b99R49-R59)
* [`lib/screens/user_settings_screen.dart`](diffhunk://#diff-d4a1a0683f152e9251e88059a7d43d921906700a617fa6a5df0c4ece467c416bR1): Imported the new notification component and updated the user settings update logic to show success or error notifications based on the outcome. [[1]](diffhunk://#diff-d4a1a0683f152e9251e88059a7d43d921906700a617fa6a5df0c4ece467c416bR1) [[2]](diffhunk://#diff-d4a1a0683f152e9251e88059a7d43d921906700a617fa6a5df0c4ece467c416bL57-L62)