### PR TITLE
14 appflutter create new building dialog

### DIFF
--- a/lib/components/construction_building.dart
+++ b/lib/components/construction_building.dart
@@ -77,7 +77,9 @@ class _ConstructBuildingDialogState extends State<ConstructBuildingDialog> {
                   ),
                 ],
               ),
-              Text("Cost\n1000\$", textAlign: TextAlign.center),
+              Text("Cost\n1000\$",
+                  textAlign: TextAlign
+                      .center), //ToDo add cost from selected construction
             ],
           ),
           SizedBox(height: 20),

--- a/lib/components/construction_building.dart
+++ b/lib/components/construction_building.dart
@@ -1,3 +1,5 @@
+import 'package:ecoland_application/components/notification.dart';
+import 'package:ecoland_application/models/building.dart';
 import 'package:ecoland_application/providers/buildings_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,86 +12,149 @@ class ConstructBuildingDialog extends StatefulWidget {
 }
 
 class _ConstructBuildingDialogState extends State<ConstructBuildingDialog> {
-  String? selectedBuildingType;
-  TextEditingController nameController =
-      TextEditingController(text: "Default Type Name");
+  String? selectedBuildingId;
+  TextEditingController nameController = TextEditingController();
   TextEditingController latController = TextEditingController();
   TextEditingController lanController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     final buildingsProvider = Provider.of<BuildingsProvider>(context);
-    return AlertDialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
-      title: Text("Construct New Building"),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          DropdownButtonFormField<String>(
-            value: selectedBuildingType,
-            decoration: InputDecoration(labelText: "Building Type"),
-            items: buildingsProvider.buildings //TODo: add list from provider
-                .map((building) => DropdownMenuItem(
-                    value: building.id, child: Text(building.name)))
-                .toList(),
-            onChanged: (value) {
-              setState(() {
-                selectedBuildingType = value;
-              });
-            },
-          ),
-          TextField(
-            controller: nameController,
-            decoration: InputDecoration(labelText: "Name"),
-          ),
-          SizedBox(height: 10),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text("Place"),
-                  Row(
-                    children: [
-                      Flexible(
-                        child: TextField(
-                          controller: lanController,
-                          keyboardType: TextInputType.number,
-                          decoration: InputDecoration(labelText: "Lan"),
-                          inputFormatters: [
-                            FilteringTextInputFormatter.allow(RegExp(r'[0-9]'))
-                          ],
-                        ),
-                      ),
-                      SizedBox(width: 10),
-                      Flexible(
-                        child: TextField(
-                          controller: latController,
-                          keyboardType: TextInputType.number,
-                          decoration: InputDecoration(labelText: "Lat"),
-                          inputFormatters: [
-                            FilteringTextInputFormatter.allow(RegExp(r'[0-9]'))
-                          ],
-                        ),
-                      ),
+    final List<DropdownMenuItem<String>> constructionList =
+        buildingsProvider.constructions.map((construction) => DropdownMenuItem(
+              value: construction.id,
+              child: Text(construction.name),
+            ));
+    return Dialog(
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 500),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text("Construct New Building",
+                style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: selectedBuildingId,
+              decoration: const InputDecoration(labelText: "Building Type"),
+              items: constructionList,
+              // items: const [
+              //   DropdownMenuItem(
+              //     value: '1',
+              //     child: Text('Farm'),
+              //   ),
+              //   DropdownMenuItem(
+              //     value: '2',
+              //     child: Text('WoodCutter'),
+              //   ),
+              // ],
+              onChanged: (value) {
+                setState(() {
+                  selectedBuildingId = value;
+                });
+              },
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(
+                  labelText: "Name", hintText: "Enter building name"),
+            ),
+            const SizedBox(height: 16),
+            const Text("Place"),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: lanController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(labelText: "Lan"),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'[0-9]'))
                     ],
                   ),
-                ],
-              ),
-              Text("Cost\n1000\$",
-                  textAlign: TextAlign
-                      .center), //ToDo add cost from selected construction
-            ],
-          ),
-          SizedBox(height: 20),
-          ElevatedButton.icon(
-            onPressed:
-                () {}, // TODO: Add logic to call start construction endpoint
-            icon: Icon(Icons.add),
-            label: Text("Construct"),
-          )
-        ],
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: TextField(
+                    controller: latController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(labelText: "Lat"),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'[0-9]'))
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              selectedBuildingId == null
+                  ? "Select a building type"
+                  : "Cost: ${buildingsProvider.constructions.firstWhere(
+                        (construction) =>
+                            construction.id.toString() == selectedBuildingId,
+                      ).cost}",
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text("Cancel"),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () async {
+                    try {
+                      if (selectedBuildingId == null) {
+                        showCustomNotification(context,
+                            message: 'Please select a building type',
+                            type: NotificationType.error);
+                        return;
+                      }
+
+                      final int? lan = int.tryParse(lanController.text);
+                      final int? lat = int.tryParse(latController.text);
+
+                      if (lan == null || lat == null) {
+                        showCustomNotification(context,
+                            message: 'Please enter valid coordinates',
+                            type: NotificationType.error);
+                        return;
+                      }
+
+                      await buildingsProvider.startConstruction(
+                        id: int.parse(selectedBuildingId!),
+                        name: nameController.text,
+                        lan: lan,
+                        lat: lat,
+                      );
+                      Navigator.of(context).pop();
+                      showCustomNotification(context,
+                          message: 'Construction started successfully',
+                          type: NotificationType.success);
+                    } catch (e) {
+                      showCustomNotification(context,
+                          message: 'Start Construction failed',
+                          type: NotificationType.error);
+                    }
+                  },
+                  icon: const Icon(Icons.add),
+                  label: const Text("Construct"),
+                  iconAlignment: IconAlignment.end,
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/components/construction_building.dart
+++ b/lib/components/construction_building.dart
@@ -1,0 +1,101 @@
+import 'package:ecoland_application/providers/buildings_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+
+class ConstructBuildingDialog extends StatefulWidget {
+  @override
+  _ConstructBuildingDialogState createState() =>
+      _ConstructBuildingDialogState();
+}
+
+class _ConstructBuildingDialogState extends State<ConstructBuildingDialog> {
+  String? selectedBuildingType;
+  TextEditingController nameController =
+      TextEditingController(text: "Default Type Name");
+  TextEditingController latController = TextEditingController();
+  TextEditingController lanController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final buildingsProvider = Provider.of<BuildingsProvider>(context);
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
+      title: Text("Construct New Building"),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          DropdownButtonFormField<String>(
+            value: selectedBuildingType,
+            decoration: InputDecoration(labelText: "Building Type"),
+            items: buildingsProvider.buildings //TODo: add list from provider
+                .map((building) => DropdownMenuItem(
+                    value: building.id, child: Text(building.name)))
+                .toList(),
+            onChanged: (value) {
+              setState(() {
+                selectedBuildingType = value;
+              });
+            },
+          ),
+          TextField(
+            controller: nameController,
+            decoration: InputDecoration(labelText: "Name"),
+          ),
+          SizedBox(height: 10),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text("Place"),
+                  Row(
+                    children: [
+                      Flexible(
+                        child: TextField(
+                          controller: lanController,
+                          keyboardType: TextInputType.number,
+                          decoration: InputDecoration(labelText: "Lan"),
+                          inputFormatters: [
+                            FilteringTextInputFormatter.allow(RegExp(r'[0-9]'))
+                          ],
+                        ),
+                      ),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: TextField(
+                          controller: latController,
+                          keyboardType: TextInputType.number,
+                          decoration: InputDecoration(labelText: "Lat"),
+                          inputFormatters: [
+                            FilteringTextInputFormatter.allow(RegExp(r'[0-9]'))
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              Text("Cost\n1000\$", textAlign: TextAlign.center),
+            ],
+          ),
+          SizedBox(height: 20),
+          ElevatedButton.icon(
+            onPressed:
+                () {}, // TODO: Add logic to call start construction endpoint
+            icon: Icon(Icons.add),
+            label: Text("Construct"),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+void showConstructBuildingDialog(BuildContext context) {
+  showDialog(
+    context: context,
+    builder: (context) => ConstructBuildingDialog(),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:ecoland_application/navigation/routes.dart';
 import 'package:ecoland_application/providers/authentication_provider.dart';
 import 'package:ecoland_application/providers/buildings_provider.dart';
 import 'package:ecoland_application/providers/user_settings_provider.dart';
+import 'package:ecoland_application/screens/overview_screen.dart';
 import 'package:ecoland_application/screens/sign_in_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -28,7 +29,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const SignInScreen(),
+      home: const OverviewScreen(), //TODO: Change back to signIn before PR
       routes: Routes.routes,
     );
   }

--- a/lib/models/building.dart
+++ b/lib/models/building.dart
@@ -33,3 +33,34 @@ class DefType {
     required this.tokenName,
   });
 }
+
+class ConBuilding {
+  final int id;
+  final String name;
+  final int cost;
+  final int time;
+
+  ConBuilding(
+      {required this.id,
+      required this.name,
+      required this.cost,
+      required this.time});
+
+  factory ConBuilding.fromJson(Map<String, dynamic> json) {
+    return ConBuilding(
+      id: json['def_id'],
+      name: json['token_name'],
+      cost: json['cost'],
+      time: json['time'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'cost': cost,
+      'iime': time,
+    };
+  }
+}

--- a/lib/providers/buildings_provider.dart
+++ b/lib/providers/buildings_provider.dart
@@ -48,8 +48,10 @@ class BuildingsProvider with ChangeNotifier {
     ),
   ];
 
+  final List<ConBuilding> _constructions = [];
   //Getters
   get buildings => _buildings;
+  get constructions => _constructions;
 
   Future<dynamic> getBuildingList() async {
     try {
@@ -70,6 +72,22 @@ class BuildingsProvider with ChangeNotifier {
     } catch (e) {
       print("getting building list failed with $e");
       return _buildings;
+    }
+  }
+
+  Future<dynamic> getConstructionList() async {
+    try {
+      final response =
+          await ApiClient().get(Endpoints.building.constructionList);
+      final List<ConBuilding> fetchedConstructions = response.data['buildings']
+          .map((resData) => ConBuilding.fromJson(resData))
+          .toList();
+      _constructions.clear();
+      _constructions.addAll(fetchedConstructions);
+      notifyListeners();
+      return _constructions;
+    } catch (e) {
+      throw Exception("Failed to fetch Construction list");
     }
   }
 }

--- a/lib/providers/buildings_provider.dart
+++ b/lib/providers/buildings_provider.dart
@@ -5,7 +5,7 @@ import 'package:ecoland_application/providers/api/endpoints.dart';
 import 'package:flutter/material.dart';
 
 class BuildingsProvider with ChangeNotifier {
-  //TODo: Test Data to be replaced with call to get buildings
+  //* Test Data will be overrriten after first call succeedss keeping test data for testing
   final List<Building> _buildings = [
     Building(
       name: 'Farm',
@@ -88,6 +88,23 @@ class BuildingsProvider with ChangeNotifier {
       return _constructions;
     } catch (e) {
       throw Exception("Failed to fetch Construction list");
+    }
+  }
+
+  Future<dynamic> startConstruction(
+      {required int id,
+      required String name,
+      required int lan,
+      required int lat}) async {
+    try {
+      final response = await ApiClient().post(Endpoints.building.construct,
+          data: {'id': id, 'name': name, 'lan': lan, 'lat': lat});
+      if (response.statusCode == 201) {
+        await getBuildingList();
+      }
+      return response;
+    } catch (e) {
+      throw Exception("Failed to post new Construction $e");
     }
   }
 }

--- a/lib/screens/overview_screen.dart
+++ b/lib/screens/overview_screen.dart
@@ -1,4 +1,5 @@
 import 'package:ecoland_application/components/building_card.dart';
+import 'package:ecoland_application/components/constructio_building.dart';
 import 'package:ecoland_application/models/building.dart';
 import 'package:ecoland_application/navigation/routes.dart';
 import 'package:ecoland_application/providers/buildings_provider.dart';
@@ -16,6 +17,7 @@ class OverviewScreen extends StatefulWidget {
 class _OverviewScreenState extends State<OverviewScreen> {
   @override
   Widget build(BuildContext context) {
+    int _selectedIndex = 0;
     final userSettings = Provider.of<UserSettingsProvider>(context);
     final buildingsP = Provider.of<BuildingsProvider>(context);
     final List<Building> buildings = buildingsP.buildings;
@@ -31,6 +33,27 @@ class _OverviewScreenState extends State<OverviewScreen> {
     }
 
     return Scaffold(
+        bottomNavigationBar: BottomNavigationBar(
+          items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.construction), label: 'build'),
+          ],
+          currentIndex: _selectedIndex,
+          selectedItemColor: Colors.amber[800],
+          onTap: (int index) {
+            switch (index) {
+              case 0:
+                print("Home clicked");
+              case 1:
+                //show construction Dialog
+                showConstructBuildingDialog(context);
+            }
+            setState(() {
+              _selectedIndex = index;
+            });
+          },
+        ),
         appBar: AppBar(
           title: const Text("Ovierview"),
           actions: [

--- a/lib/screens/overview_screen.dart
+++ b/lib/screens/overview_screen.dart
@@ -46,7 +46,6 @@ class _OverviewScreenState extends State<OverviewScreen> {
               case 0:
                 print("Home clicked");
               case 1:
-                //show construction Dialog
                 showConstructBuildingDialog(context);
             }
             setState(() {

--- a/lib/screens/overview_screen.dart
+++ b/lib/screens/overview_screen.dart
@@ -1,5 +1,5 @@
 import 'package:ecoland_application/components/building_card.dart';
-import 'package:ecoland_application/components/constructio_building.dart';
+import 'package:ecoland_application/components/construction_building.dart';
 import 'package:ecoland_application/models/building.dart';
 import 'package:ecoland_application/navigation/routes.dart';
 import 'package:ecoland_application/providers/buildings_provider.dart';


### PR DESCRIPTION
This pull request introduces a new feature for constructing buildings and includes several changes across multiple files to support this functionality. The main changes include adding a new dialog for building construction, updating the `BuildingsProvider` to handle construction-related data, and modifying the `OverviewScreen` to include a navigation bar for accessing the construction dialog.

New feature implementation:

* [`lib/components/construction_building.dart`](diffhunk://#diff-98f92dd56b090b4d45d080ee45c0d8d98e359de03877fbedee392374a2471d50R1-R168): Added a new dialog, `ConstructBuildingDialog`, for constructing buildings, including form fields for building type, name, and coordinates, and buttons to cancel or start the construction process.

Provider updates:

* [`lib/providers/buildings_provider.dart`](diffhunk://#diff-cef566dc8177dce6be7b0377e72bed2d8ae242c3ab408a8f05076446e9d1120aR51-R54): Added a new list `_constructions` to store construction data, and methods `getConstructionList` and `startConstruction` to fetch construction options and initiate a construction, respectively. [[1]](diffhunk://#diff-cef566dc8177dce6be7b0377e72bed2d8ae242c3ab408a8f05076446e9d1120aR51-R54) [[2]](diffhunk://#diff-cef566dc8177dce6be7b0377e72bed2d8ae242c3ab408a8f05076446e9d1120aR77-R109)

Model updates:

* [`lib/models/building.dart`](diffhunk://#diff-723e33b5ecb358f3a3f9d7dffee4c1ccf7cdea920762a5a538467bbbbd69cb91R36-R66): Introduced a new class `ConBuilding` to represent construction options, with fields for `id`, `name`, `cost`, and `time`, and methods for JSON serialization and deserialization.

Screen updates:

* [`lib/screens/overview_screen.dart`](diffhunk://#diff-662ddf78c35db80e6f4aea6bdb7f48ff34adb9488606d2b5fe7445fef77a8e6aR36-R55): Added a bottom navigation bar to the `OverviewScreen` with options to navigate to the home screen or open the construction dialog.

Other changes:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L31-R32): Temporarily set the home screen to `OverviewScreen` for testing purposes.